### PR TITLE
Fix generated workflow to merge results

### DIFF
--- a/apps/engine/lib/workflow_codegen.ex
+++ b/apps/engine/lib/workflow_codegen.ex
@@ -47,9 +47,14 @@ end
   # Generates the body of the run/1 function, respecting dependencies
   defp exec_function_body(nodes, edges) do
     order = topo_sort(nodes, edges)
-    Enum.map(order, fn node_id ->
-      "    { :ok, #{node_id}_out } = #{node_id}(input)"
-    end)
+    ["    state = input" |
+     Enum.flat_map(order, fn node_id ->
+       [
+         "    {:ok, #{node_id}_out} = #{node_id}(state)",
+         "    state = Map.merge(state, #{node_id}_out)"
+       ]
+     end) ++ ["    state"]
+    ]
     |> Enum.join("\n")
   end
 


### PR DESCRIPTION
## Summary
- preserve running state when generating workflow modules
- merge each node's output into the accumulated state

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aad9cac988329acbc7b12bbddfb2d