### PR TITLE
Fix duplicated metrics test module

### DIFF
--- a/apps/a2a_agent_web/test/a2a_agent_web_web/metrics_test.exs
+++ b/apps/a2a_agent_web/test/a2a_agent_web_web/metrics_test.exs
@@ -29,30 +29,3 @@ defmodule A2aAgentWebWeb.MetricsTest do
     assert body =~ "task_request"
   end
 end
-defmodule A2aAgentWebWeb.MetricsTest do
-  use A2aAgentWebWeb.ConnCase, async: true
-
-  @doc """
-  Validates that the /metrics endpoint returns Prometheus metrics and that counters increment for A2A actions.
-  """
-  test "GET /metrics returns Prometheus metrics and increments on A2A POST", %{conn: conn} do
-    # Trigger an A2A message to increment a counter
-    conn = post(conn, "/api/a2a", %{
-      "type" => "task_request",
-      "sender" => "agent1",
-      "recipient" => "agent2",
-      "payload" => %{
-        "graph" => %{"nodes" => [], "edges" => []},
-        "agent_map" => %{},
-        "input" => %{}
-      }
-    })
-    assert json_response(conn, 200)["status"] == "ok"
-
-    # Now check /metrics
-    conn = get(recycle(conn), "/metrics")
-    body = response(conn, 200)
-    assert body =~ "a2a_messages_total"
-    assert body =~ "task_request"
-  end
-end


### PR DESCRIPTION
## Summary
- remove duplicate `MetricsTest` module

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf46fd788329bd35d9ecd6ecc4ad