### PR TITLE
Clarify MapOperator pass-through documentation

### DIFF
--- a/apps/operator/lib/operator.ex
+++ b/apps/operator/lib/operator.ex
@@ -7,16 +7,16 @@ defmodule Operator do
   @callback call(map()) :: map()
 end
 
-# MapOperator: Applies a function to an input value and returns the result
+# MapOperator: Moves the value stored under "input" to "output" unchanged
 # Example usage: Operator.MapOperator.call(%{"input" => 42})
 defmodule Operator.MapOperator do
   @moduledoc """
-  Applies a function to an input value and returns the result.
+  Passes through the data from `"input"` to `"output"` without modification.
   """
   @behaviour Operator
 
   @doc """
-  Calls the map operator.
+  Moves `"input"` to `"output"` unchanged.
   """
   @impl true
   @spec call(map()) :: map()


### PR DESCRIPTION
## Summary
- update `Operator.MapOperator` docs to state it moves `"input"` to `"output"`
- adjust surrounding comments accordingly

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf4aa72c8329b6f08a3d634dc510