### PR TITLE
Refactor AggregateOperator reduction order

### DIFF
--- a/apps/a2a_agent_web/README.md
+++ b/apps/a2a_agent_web/README.md
@@ -193,7 +193,7 @@ The A2A Agent Web app includes a robust, distributed agent registry and discover
 
 **Key Features:**
 - **Aggregation/Reduction:** Applies a reducer function to a list of inputs and an initial value, producing a single aggregated result.
-- **Order Guarantee:** Explicitly reverses input list to ensure left-to-right reduction, matching Elixir convention and documentation.
+ - **Order Guarantee:** Processes inputs left-to-right using recursion to maintain the expected reduction order.
 - **Composable:** Can be used as a node in workflow graphs or combined with other operators for aggregation logic.
 - **Example Usage:** See inline doctest for practical usage.
 

--- a/apps/a2a_agent_web/lib/a2a_agent_web_web/operators/aggregate_operator.ex
+++ b/apps/a2a_agent_web/lib/a2a_agent_web_web/operators/aggregate_operator.ex
@@ -10,15 +10,13 @@ defmodule A2aAgentWebWeb.Operators.AggregateOperator do
 
   @spec run([any()], any(), (any(), any() -> any())) :: any()
   @doc """
-  Aggregates left-to-right: reducer is called as reducer(acc, x) for x in inputs.
-  If your reducer is producing reversed results, check argument order in your reducer function.
-  """
-  @doc """
-  Aggregates left-to-right: reducer is always called as reducer(acc, x) for x in inputs.
-
-  Due to an observed nonstandard reduction order in this environment, we explicitly reverse the input list to guarantee left-to-right aggregation, matching Enum.reduce/3 documentation and Elixir convention.
+  Aggregates left-to-right: reducer is called as `reducer(acc, x)` for each `x` in `inputs`.
+  If your reducer appears to produce reversed results, check the argument order in your reducer function.
   """
   def run(inputs, init, reducer) when is_list(inputs) and is_function(reducer, 2) do
-    Enum.reduce(Enum.reverse(inputs), init, fn acc, x -> reducer.(acc, x) end)
+    do_reduce(inputs, init, reducer)
   end
+
+  defp do_reduce([], acc, _reducer), do: acc
+  defp do_reduce([h | t], acc, reducer), do: do_reduce(t, reducer.(acc, h), reducer)
 end


### PR DESCRIPTION
## Summary
- remove Enum.reverse from `AggregateOperator.run/3`
- explicitly reduce inputs left-to-right
- update README docs for new behaviour

## Testing
- `elixir -r apps/a2a_agent_web/lib/a2a_agent_web_web/operators/aggregate_operator.ex -e 'ExUnit.start(); Code.require_file("apps/a2a_agent_web/test/a2a_agent_web_web/operators/aggregate_operator_test.exs")'`


------
https://chatgpt.com/codex/tasks/task_e_686aaf4ca36483298f5fda0b4e221896