### PR TITLE
Fix module name typo

### DIFF
--- a/apps/a2a_agent_web/lib/a2a_agent_web_web/workflow_runner.ex
+++ b/apps/a2a_agent_web/lib/a2a_agent_web_web/workflow_runner.ex
@@ -10,7 +10,7 @@ defmodule A2AAgentWeb.WorkflowRunner do
       A2AAgentWeb.WorkflowRunner.run_exs("workflows/summarize_and_analyze.exs", %{"text" => "Elixir is awesome!"})
   """
 
-  alias A2AAgentWeb.WorkflowYAMELoader
+  alias A2AAgentWeb.WorkflowYAMLLoader
   # For Elixir macro DSL, no alias needed; Code.eval_file/1 returns the workflow structure
 
   @doc """
@@ -28,7 +28,7 @@ defmodule A2AAgentWeb.WorkflowRunner do
   """
   @spec run_yaml(String.t(), map(), module()) :: any()
   def run_yaml(yaml_path, input \\ %{}, engine \\ Engine) do
-    case WorkflowYAMELoader.load(yaml_path) do
+    case WorkflowYAMLLoader.load(yaml_path) do
       {:ok, %{:nodes => _nodes, :edges => _edges} = workflow} ->
         engine.run(workflow, input)
       {:ok, %{"nodes" => _nodes, "edges" => _edges} = workflow} ->

--- a/apps/a2a_agent_web/lib/a2a_agent_web_web/workflow_yaml_loader.ex
+++ b/apps/a2a_agent_web/lib/a2a_agent_web_web/workflow_yaml_loader.ex
@@ -1,10 +1,10 @@
-defmodule A2AAgentWeb.WorkflowYAMELoader do
+defmodule A2AAgentWeb.WorkflowYAMLLoader do
   @moduledoc """
   Loads and parses workflow definitions from YAML files into the internal graph structure
   compatible with the XCS engine. Intended for use with workflows defined in the YAML DSL.
 
   Example usage:
-      {:ok, workflow} = A2AAgentWeb.WorkflowYAMELoader.load("workflows/summarize_and_analyze.yaml")
+      {:ok, workflow} = A2AAgentWeb.WorkflowYAMLLoader.load("workflows/summarize_and_analyze.yaml")
       # => %{nodes: [...], edges: [...]} (ready for XCS)
   """
 

--- a/apps/a2a_agent_web/lib/mix/tasks/workflow.run.ex
+++ b/apps/a2a_agent_web/lib/mix/tasks/workflow.run.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Workflow.Run do
 
     IO.puts("DEBUG: YAML path: #{yaml_path}")
     IO.puts("DEBUG: File.exists?: #{File.exists?(yaml_path)}")
-    case A2AAgentWeb.WorkflowYAMELoader.load(yaml_path) do
+    case A2AAgentWeb.WorkflowYAMLLoader.load(yaml_path) do
       {:ok, workflow} ->
         converted = convert_workflow(workflow)
         graph = workflow_to_graph(converted)

--- a/apps/a2a_agent_web/test/a2a_agent_web_web/workflows/workflow_yaml_loader_test.exs
+++ b/apps/a2a_agent_web/test/a2a_agent_web_web/workflows/workflow_yaml_loader_test.exs
@@ -1,10 +1,10 @@
-defmodule A2AAgentWeb.WorkflowYAMELoaderTest do
+defmodule A2AAgentWeb.WorkflowYAMLLoaderTest do
   @moduledoc """
-  Tests for the WorkflowYAMELoader module, ensuring YAML workflows are parsed correctly.
+  Tests for the WorkflowYAMLLoader module, ensuring YAML workflows are parsed correctly.
   """
   use ExUnit.Case, async: true
 
-  import A2AAgentWeb.WorkflowYAMELoader
+  import A2AAgentWeb.WorkflowYAMLLoader
 
   @yaml_path "workflows/summarize_and_analyze.yaml"
 


### PR DESCRIPTION
## Summary
- rename `WorkflowYAMELoader` to `WorkflowYAMLLoader`
- update references in runner, mix task and tests

## Testing
- `mix test apps/a2a_agent_web/test/a2a_agent_web_web/workflows/workflow_yaml_loader_test.exs` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf4d38148329b7b85d9a59f7204a